### PR TITLE
Switch to using token swap service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,6 @@ Dependencies
 
 - A non-Facebook Spotify username and password.
 
-- A registered application on https://developer.spotify.com, follow the instruction
-  on https://developer.spotify.com/web-api/tutorial/. Create a  Client ID and Secret Key,
-  then finish the tutorial to obtain a refresh token.
-
 - ``Mopidy`` >= 0.19.0. The music server that Mopidy-Spotify-Tunigo extends.
 
 - ``Mopidy-Spotify`` >= 1.2.0. The Mopidy extension for playing music from
@@ -42,12 +38,14 @@ install the package from PyPI::
 Configuration
 =============
 
+To run this extension you need to authorize it against you Spotify account, to do this visit
+https://www.mopidy.com/authenticate/#spotify and follow the instructions.
+
 Example configuration::
 
     [spotify_web]
-    spotify_client_id = 'YOUR_CLIENT_ID'
-    spotify_client_secret = 'YOUR_SECRET'
-    refresh_token = 'YOUR_REFRESH_TOKEN'
+    client_id = ... client_id value you got from mopidy.com ...
+    client_secret = ... client_secret value you got from mopidy.com ...
 
 The following configuration values are available:
 
@@ -56,12 +54,10 @@ The following configuration values are available:
 
 - ``spotify_web/client_id``: Your Spotify application client id. You *must* provide this.
 
-- ``spotify_web/spotify_client_secret``: Your Spotify application secret key. You *must* provide this.
+- ``spotify_web/client_secret``: Your Spotify application secret key. You *must* provide this.
 
-- ``spotify_web/refresh_token``: Your Spotify refresh token. You *must* provide this.
-
-- ``spotify_web/auth_server_url``: url to the authorization endpoint
-  of the Spotify Accounts service. Defaults to https://accounts.spotify.com/api/token.
+- ``spotify_web/token_url``: url to the authorization endpoint
+  of the Mopidy OAuth bridge for Spotify. Defaults to https://auth.mopidy.com/spotify/token.
 
 
 Project resources
@@ -81,6 +77,7 @@ v0.2.0 (unreleased)
 - Use ``requests`` module for fetching tokens.
 - Blocking initialization moved out of critical startup path.
 - Various internal cleanups to make code more Pythonic.
+- Switch to using Mopidy's token swap service for simpler authentication.
 
 v0.1.0 (2015-05-03)
 -------------------

--- a/mopidy_spotify_web/__init__.py
+++ b/mopidy_spotify_web/__init__.py
@@ -24,10 +24,9 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
-        schema['spotify_client_id'] = config.String()
-        schema['spotify_client_secret'] = config.String()
-        schema['refresh_token'] = config.String()
-        schema['auth_server_url'] = config.String()
+        schema['client_id'] = config.String()
+        schema['client_secret'] = config.String()
+        schema['token_url'] = config.String()
         return schema
 
     def setup(self, registry):

--- a/mopidy_spotify_web/ext.conf
+++ b/mopidy_spotify_web/ext.conf
@@ -1,6 +1,5 @@
 [spotify_web]
 enabled = true
-spotify_client_id = clientid
-spotify_client_secret = clientid
-refresh_token = token
-auth_server_url= https://accounts.spotify.com/api/token
+client_id =
+client_secret =
+token_url = https://auth.mopidy.com/spotify/token

--- a/mopidy_spotify_web/library.py
+++ b/mopidy_spotify_web/library.py
@@ -42,10 +42,9 @@ def get_tracks_from_web_api(token):
 def get_fresh_token(config):
     try:
         logger.debug("authenticating")
-        auth = (config['spotify_client_id'], config['spotify_client_secret'])
-        response = requests.post(config['auth_server_url'], auth=auth, data={
-            'grant_type': 'refresh_token',
-            'refresh_token': config['refresh_token'],
+        auth = (config['client_id'], config['client_secret'])
+        response = requests.post(config['token_url'], auth=auth, data={
+            'grant_type': 'client_credentials',
         })
         logger.debug("authentication response: %s", response.content)
         access_token = response.json()['access_token']


### PR DESCRIPTION
In the future I will likely move the auth page to just https://www.mopidy.com/authenticate/ - but since this is all rather new I've left it "hidden" in this sub-page for now. When we move I'll see about redirecting the old page.

Currently the swap service is configured to ask for the following scopes: playlist-read-private, playlist-read-collaborative, user-follow-read, user-library-read. So all the read-only ones that might come in handy, if this should change please let me know.

Oh and for reference the swap service is https://github.com/adamcik/oauthclientbridge which is the implementation of what I described in https://github.com/mopidy/mopidy-spotify/issues/16#issuecomment-105457471
