### PR TITLE
spotify browse webapi: passthrough implementation, no cache

### DIFF
--- a/mopidy_spotify_web/library.py
+++ b/mopidy_spotify_web/library.py
@@ -72,9 +72,9 @@ class SpotifyWebLibraryProvider(backend.LibraryProvider):
             Ref.directory(uri='spotifyweb:categories', name='Categories')]
 
     def refresh(self, uri=None):
-        token = get_fresh_token(self.backend.config)
-        if token is not None:
-            tracks = get_tracks_from_web_api(token)
+        self.token = get_fresh_token(self.backend.config)
+        if self.token is not None:
+            tracks = get_tracks_from_web_api(self.token)
         else:
             tracks = []
         self._cache = Cache(tracks)

--- a/mopidy_spotify_web/library.py
+++ b/mopidy_spotify_web/library.py
@@ -133,8 +133,8 @@ class SpotifyWebLibraryProvider(backend.LibraryProvider):
                     arr += [ Ref.album(uri=album['uri'],
                                     name=album['name']) for album in res['albums']['items'] ]
                 return arr
-            except Exception as e:
-                print('error', e);
+            except spotipy.SpotifyException as e:
+                logger.error('error, access_token invalid ?')
                 return []
         else:
             return []

--- a/mopidy_spotify_web/library.py
+++ b/mopidy_spotify_web/library.py
@@ -90,7 +90,7 @@ class SpotifyWebLibraryProvider(backend.LibraryProvider):
             if time.monotonic() < self._access_token_expires - 60:
                 return self._sp
         token_res = get_fresh_token(self.backend.config)
-        if not token_res.has_key('access_token'):
+        if token_res is None or not token_res.has_key('access_token'):
             raise spotipy.SpotifyException(0, '', 'no refresh_token')
         self._access_token = token_res['access_token']
         self._access_token_expires = time.monotonic() + token_res['expires_in']


### PR DESCRIPTION
https://developer.spotify.com/web-api/browse-endpoints/

bugs to fix (patches are coming soon):
- refresh token
- maybe prefix these urls with browse: ?
- multi-page
